### PR TITLE
Fix duplicate definition of mysql_connect by renaming local version t…

### DIFF
--- a/connection.c
+++ b/connection.c
@@ -94,7 +94,7 @@ mysql_get_connection(ForeignServer *server, UserMapping *user, mysql_opt *opt)
 	}
 	if (entry->conn == NULL)
 	{
-		entry->conn = mysql_connect(
+		entry->conn = mysql_connect_fdw(
 			opt->svr_address,
 			opt->svr_username,
 			opt->svr_password,
@@ -170,7 +170,7 @@ mysql_rel_connection(MYSQL *conn)
 
 
 MYSQL*
-mysql_connect(
+mysql_connect_fdw(
 	char *svr_address,
 	char *svr_username,
 	char *svr_password,

--- a/mysql_fdw.h
+++ b/mysql_fdw.h
@@ -189,7 +189,7 @@ extern void mysql_deparse_analyze(StringInfo buf, char *dbname, char *relname);
 
 /* connection.c headers */
 MYSQL *mysql_get_connection(ForeignServer *server, UserMapping *user, mysql_opt *opt);
-MYSQL *mysql_connect(char *svr_address, char *svr_username, char *svr_password, char *svr_database,
+MYSQL *mysql_connect_fdw(char *svr_address, char *svr_username, char *svr_password, char *svr_database,
 							 int svr_port, bool svr_sa, char *svr_init_command,
 							 char *ssl_key, char *ssl_cert, char *ssl_ca, char *ssl_capath,
 							 char *ssl_cipher);


### PR DESCRIPTION
…o mysql_connect_fdw.

When compiling against MariaDB 10.23.1 on Debian the definition of mysql_connect in the mysql_fdw source conflicts with the definition in mysql.h; simple workaround with a rename.